### PR TITLE
Cat Command Hotfix

### DIFF
--- a/cogs/cat.py
+++ b/cogs/cat.py
@@ -13,13 +13,13 @@ async def process_cat_command(self, ctx):
     if ctx.channel.id in self.global_variables.config['bot']['channels']:
         connector = ProxyConnectorWrapper().connector
         async with aiohttp.ClientSession(connector=connector) as session:
-            catPicture = requests.get('http://thecatapi.com/api/images/get.php')
-            if catPicture.status_code == 200:
-                catPicture = catPicture.url
+            cat_picture = requests.get('http://thecatapi.com/api/images/get.php')
+            if cat_picture.status_code == 200:
+                cat_picture = cat_picture.url
             colors = [0xFF0000, 0xFF7F00, 0xFFFF00, 0x00FF00, 0x0000FF, 0x2E2B5F, 0x8B00FF]
-            embed_Var = discord.Embed(title="Here is a cat! 🐈", color=random.choice(colors))
-            embed_Var.set_image(url=catPicture)
-            await ctx.send(embed=embed_Var)
+            embed_var = discord.Embed(title="Here is a cat! 🐈", color=random.choice(colors))
+            embed_var.set_image(url=cat_picture)
+            await ctx.send(embed=embed_var)
             pass
 
 

--- a/cogs/cat.py
+++ b/cogs/cat.py
@@ -5,12 +5,14 @@ import random
 from discord.ext import commands
 from discord_slash import cog_ext, SlashContext
 
+from customobjects import ProxyConnectorWrapper
 from globalvariables import GlobalVariables
 
 
 async def process_cat_command(self, ctx):
     if ctx.channel.id in self.global_variables.config['bot']['channels']:
-        async with aiohttp.ClientSession() as session:
+        connector = ProxyConnectorWrapper().connector
+        async with aiohttp.ClientSession(connector=connector) as session:
             catPicture = requests.get('http://thecatapi.com/api/images/get.php')
             if catPicture.status_code == 200:
                 catPicture = catPicture.url

--- a/cogs/cat.py
+++ b/cogs/cat.py
@@ -1,4 +1,3 @@
-import requests
 import discord
 import aiohttp
 import random
@@ -12,15 +11,14 @@ from globalvariables import GlobalVariables
 async def process_cat_command(self, ctx):
     if ctx.channel.id in self.global_variables.config['bot']['channels']:
         connector = ProxyConnectorWrapper().connector
-        async with aiohttp.ClientSession(connector=connector) as session:
-            cat_picture = requests.get('http://thecatapi.com/api/images/get.php')
-            if cat_picture.status_code == 200:
-                cat_picture = cat_picture.url
-            colors = [0xFF0000, 0xFF7F00, 0xFFFF00, 0x00FF00, 0x0000FF, 0x2E2B5F, 0x8B00FF]
-            embed_var = discord.Embed(title="Here is a cat! 🐈", color=random.choice(colors))
-            embed_var.set_image(url=cat_picture)
-            await ctx.send(embed=embed_var)
-            pass
+        async with aiohttp.ClientSession(connector=connector) as cs:
+            async with cs.get('https://thecatapi.com/api/images/get.php') as r:
+                if r.status == 200:
+                    cat_picture = r.url
+                colors = [0xFF0000, 0xFF7F00, 0xFFFF00, 0x00FF00, 0x0000FF, 0x2E2B5F, 0x8B00FF]
+                embed_var = discord.Embed(title="Here is a cat! 🐈", color=random.choice(colors))
+                embed_var.set_image(url=cat_picture)
+                await ctx.send(embed=embed_var)
 
 
 class Cat(commands.Cog):


### PR DESCRIPTION
Make the cat command respect proxy settings and use aiohttp like the rest of our program instead of requests.